### PR TITLE
Fixing iris image location in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - db
     #build: ./iris-api
-    image: iris-api
+    image: quay.io/iris/iris
     links:
       - db
     ports:


### PR DESCRIPTION
Fixes #1 by pointing to the iris image on quay.io

```
┌─(me@machine)──(2018-12-24 @ 14:45:16)──( ~/tmp/iris-docker-compose  (master) ) 
└─$ > git diff 
diff --git a/docker-compose.yml b/docker-compose.yml
index 8b59ba7..300e528 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - db
     #build: ./iris-api
-    image: iris-api
+    image: quay.io/iris/iris
     links:
       - db
     ports:

┌─(me@machine)──(2018-12-24 @ 14:45:22)──( ~/tmp/iris-docker-compose  (master) ) 
└─$ > make
rm -rf iris-api iris-relay
git clone --depth 1 git@github.com:linkedin/iris-api.git iris-api
Cloning into 'iris-api'...
remote: Enumerating objects: 253, done.
remote: Counting objects: 100% (253/253), done.
remote: Compressing objects: 100% (234/234), done.
remote: Total 253 (delta 14), reused 123 (delta 4), pack-reused 0
Receiving objects: 100% (253/253), 2.06 MiB | 3.21 MiB/s, done.
Resolving deltas: 100% (14/14), done.
git clone --depth 1 git@github.com:linkedin/iris-relay.git iris-relay
Cloning into 'iris-relay'...
remote: Enumerating objects: 45, done.
remote: Counting objects: 100% (45/45), done.
remote: Compressing objects: 100% (39/39), done.
remote: Total 45 (delta 2), reused 25 (delta 0), pack-reused 0
Receiving objects: 100% (45/45), 28.92 KiB | 871.00 KiB/s, done.
Resolving deltas: 100% (2/2), done.
install -d logs/iris-{api,relay}/{nginx,uwsgi}
docker-compose up -d
Starting iris-docker-compose_db_1 ... done
Starting iris-docker-compose_iris-api_1 ... done
Starting iris-docker-compose_prometheus_1 ... done

┌─(me@machine)──(2018-12-24 @ 14:45:32)──( ~/tmp/iris-docker-compose  (master) ) 
└─$ > 
```